### PR TITLE
Added working delete function for products

### DIFF
--- a/electronicDojo/data/testDeleteProduct.php
+++ b/electronicDojo/data/testDeleteProduct.php
@@ -1,0 +1,4 @@
+INSERT INTO `products` (`product_ID`, `product_name`, `bio`, `price`, `loyalty_points`, `brand`, `category`)
+VALUES ('10', 'test', 'test', '1200.01', '50', 'test', 'Laptop');
+
+INSERT INTO `laptop` (`laptop_ID`, `manufacturer`, `image`, `product_ID_laptop`) VALUES (NULL, 'test', 'null', '10');

--- a/electronicDojo/lib/sqlQueries.php
+++ b/electronicDojo/lib/sqlQueries.php
@@ -30,7 +30,16 @@ function checkAdminQ(){
 }
 
 function deleteProductQ(){
-    return "DELETE 
-    FROM products WHERE product_ID = :product_ID";
+    return "DELETE FROM products WHERE product_ID = :product_ID";
+}
+
+function deleteFromCategoryQ($categoryLower)
+{
+    return "DELETE FROM $categoryLower WHERE product_ID_$categoryLower = :product_ID";
+}
+
+function getCategoryQ()
+{
+    return "SELECT category FROM products WHERE product_ID = :product_ID";
 }
 

--- a/electronicDojo/productModify.php
+++ b/electronicDojo/productModify.php
@@ -11,12 +11,33 @@ if (isset($_GET['product_ID'])){
 
     $prodID = $_GET["product_ID"];
 
-    $sql = "DELETE 
-    FROM products WHERE product_ID = :product_ID";
+    $connection->beginTransaction();
 
-    $statement = $connection->prepare($sql);
-    $statement->bindParam(":product_ID", $prodID);
-    $statement->execute();
+    try {
+        $sqlGetCategory = getCategoryQ();
+        $statementGetCategory = $connection->prepare($sqlGetCategory);
+        $statementGetCategory->bindParam(":product_ID", $prodID);
+        $statementGetCategory->execute();
+        $category = $statementGetCategory->fetchColumn();
+
+        $categoryLower = strtolower($category);
+
+
+        $sqlDeleteCategory = deleteFromCategoryQ($categoryLower);
+        $statementCategory = $connection->prepare($sqlDeleteCategory);
+        $statementCategory->bindParam(":product_ID", $prodID);
+        $statementCategory->execute();
+
+        $sqlDeleteProducts = deleteProductQ();
+        $statementProducts = $connection->prepare($sqlDeleteProducts);
+        $statementProducts->bindParam(":product_ID", $prodID);
+        $statementProducts->execute();
+
+        $connection->commit();
+    } catch (Exception $e) {
+
+        $connection->rollback();
+    }
 }
 
 function fetchAllProducts($connection) {

--- a/electronicDojo/src/DBconnect.php
+++ b/electronicDojo/src/DBconnect.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once './config.php';
+require_once 'config.php';
 
 try{
     $connection = new PDO($dsn, $username, $password, $options);


### PR DESCRIPTION
An admin can read and delete products. A slight issue with the naming of the phones table as it converts the category string from a product to lower in order to delete from the table the product_ID foreign key is in, Phones will need to be changed to phone in order for the delete function to work with phone products.